### PR TITLE
Add webots driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,23 @@ kart state based on CAN bus status.
 ### Topics
 
 #### Publishes
+
 - `/odom_ack` : AckermannDrive message that contains the current steering angle received on the topic `/robot/cmd_vel`
-as well as the current throttle/brake value which will be stored in the resulting messages acceleration field.
-The speed field of the AckermannDrive message contains the last received speed message from the CAN bus.
-If no speed messages have been received, then the speed field will be zero.
+  as well as the current throttle/brake value which will be stored in the resulting messages acceleration field.
+  The speed field of the AckermannDrive message contains the last received speed message from the CAN bus.
+  If no speed messages have been received, then the speed field will be zero.
 
 #### Subscribes
+
 - `/robot/ack_vel`: AckermannDrive messages coming from the controller that contain steering angle and throttle/brake
-values to be sent to the CAN bus.
+  values to be sent to the CAN bus.
 
 ### Params
+
 - `port_search_pattern`: The string pattern to look for when looking for a teensy device. This can be either a top level
-`/dev/ttyACM*` or the serial devices id as found in `/dev/serial/by-id`.
-  By default, phnx_io_ros will use `/dev/serial/by-id/usb-Teensyduino_USB_Serial*` which should point to a Teensy serial monitor
+  `/dev/ttyACM*` or the serial devices id as found in `/dev/serial/by-id`.
+  By default, phnx_io_ros will use `/dev/serial/by-id/usb-Teensyduino_USB_Serial*` which should point to a Teensy serial
+  monitor
   if plugged in.
 - `baud_rate`: Baud rate to use when connecting to a Teensy.
 - `max_throttle_speed`: Value that we consider to be full throttle. It Should be consistent with controller.
@@ -42,7 +46,8 @@ values to be sent to the CAN bus.
 
 ### gz_io_ros
 
-This package acts as a fake for phnx_io_ros and allows the ROS aspect of Phoenix to interface with Ignition Gazebo, which
+This package acts as a fake for phnx_io_ros and allows the ROS aspect of Phoenix to interface with Ignition Gazebo,
+which
 runs our simulation environment. This packages primary function is to take in odom coming from the simulation and twist
 values from ROS and convert those into AckermannDrive messages to be logged
 with '[data_logger](https://github.com/ISC-Project-Phoenix/data_logger)'
@@ -69,4 +74,21 @@ with '[data_logger](https://github.com/ISC-Project-Phoenix/data_logger)'
 
 ### Misc
 
-see [the design for more info](https://github.com/ISC-Project-Phoenix/design/blob/main/software/ros/gz_io_ros.md) 
+see [the design for more info](https://github.com/ISC-Project-Phoenix/design/blob/main/software/ros/gz_io_ros.md)
+
+### wb_io_ros
+
+This package contains a webots plugin that simulates the phoenix can bus, like gz_io_ros. This bridges any webots
+sensors that have no default plugins, and also exposes an interface for the actuation of AckermannDrive messages.
+See the tutorial for an example on how to use
+this: [tutorial](https://docs.ros.org/en/foxy/Tutorials/Beginner-Client-Libraries/Pluginlib.html).
+
+### Topics
+
+#### Publishes
+
+- `/odom_can`: Encoder data from webots
+
+#### Subscribes
+
+- `/ack_vel`: AckermannDrive commands to actuate

--- a/wb_io_ros/.clang-format
+++ b/wb_io_ros/.clang-format
@@ -1,0 +1,27 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+TabWidth: 2
+IndentWidth: 4
+AccessModifierOffset: -4
+BraceWrapping:
+  AfterCaseLabel:         false
+  AfterClass:             false
+  AfterControlStatement:  "false"
+  AfterEnum:              false
+  AfterFunction:          false
+  AfterNamespace:         false
+  AfterObjCDeclaration:   false
+  AfterStruct:            false
+  AfterUnion:             false
+  AfterExternBlock:       false
+  BeforeCatch:            false
+  BeforeElse:             false
+  IndentBraces:           false
+BreakBeforeBraces: Custom
+ColumnLimit: 120
+DerivePointerAlignment: false
+PointerAlignment: Left
+ReflowComments: false
+...

--- a/wb_io_ros/CMakeLists.txt
+++ b/wb_io_ros/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.8)
+project(wb_io_ros)
+
+if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif ()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(ackermann_msgs REQUIRED)
+find_package(webots_ros2_driver REQUIRED)
+find_package(pluginlib REQUIRED)
+
+# Export the plugin configuration file
+pluginlib_export_plugin_description_file(webots_ros2_driver wb_io_ros.xml)
+
+add_library(wb_io_ros SHARED src/wb_io_ros.cpp)
+target_include_directories(wb_io_ros PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+target_compile_features(wb_io_ros PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+ament_target_dependencies(
+        wb_io_ros
+        "rclcpp"
+        "geometry_msgs"
+        "webots_ros2_driver"
+        "ackermann_msgs"
+        "pluginlib"
+)
+
+install(TARGETS
+        wb_io_ros
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+)
+
+if (BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    # the following line skips the linter which checks for copyrights
+    # comment the line when a copyright and license is added to all source files
+    set(ament_cmake_copyright_FOUND TRUE)
+    # the following line skips cpplint (only works in a git repo)
+    # comment the line when this package is in a git repo and when
+    # a copyright and license is added to all source files
+    set(ament_cmake_cpplint_FOUND TRUE)
+    ament_lint_auto_find_test_dependencies()
+endif ()
+
+ament_package()

--- a/wb_io_ros/CMakeLists.txt
+++ b/wb_io_ros/CMakeLists.txt
@@ -9,6 +9,7 @@ endif ()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(ackermann_msgs REQUIRED)
 find_package(webots_ros2_driver REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -28,10 +29,12 @@ ament_target_dependencies(
         "webots_ros2_driver"
         "ackermann_msgs"
         "pluginlib"
+        "nav_msgs"
 )
 
 install(TARGETS
         wb_io_ros
+        EXPORT export_${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -49,4 +52,13 @@ if (BUILD_TESTING)
     ament_lint_auto_find_test_dependencies()
 endif ()
 
+ament_export_include_directories(
+        include
+)
+ament_export_libraries(
+        wb_io_ros
+)
+ament_export_targets(
+        export_${PROJECT_NAME}
+)
 ament_package()

--- a/wb_io_ros/LICENSE
+++ b/wb_io_ros/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/wb_io_ros/include/wb_io_ros/wb_io_ros.hpp
+++ b/wb_io_ros/include/wb_io_ros/wb_io_ros.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ackermann_msgs/msg/ackermann_drive.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "webots_ros2_driver/PluginInterface.hpp"
+#include "webots_ros2_driver/WebotsNode.hpp"
+
+namespace wb_io_ros {
+class WbIoRos : public webots_ros2_driver::PluginInterface {
+public:
+    void step() override;
+    void init(webots_ros2_driver::WebotsNode* node, std::unordered_map<std::string, std::string>& parameters) override;
+
+private:
+    void ack_cb(ackermann_msgs::msg::AckermannDrive::SharedPtr msg);
+
+    rclcpp::Subscription<ackermann_msgs::msg::AckermannDrive>::SharedPtr ack_sub;
+    ackermann_msgs::msg::AckermannDrive control;
+};
+}  // namespace wb_io_ros

--- a/wb_io_ros/include/wb_io_ros/wb_io_ros.hpp
+++ b/wb_io_ros/include/wb_io_ros/wb_io_ros.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "ackermann_msgs/msg/ackermann_drive.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "webots/vehicle/driver.h"
 #include "webots_ros2_driver/PluginInterface.hpp"
 #include "webots_ros2_driver/WebotsNode.hpp"
 
@@ -17,6 +18,10 @@ private:
     void ack_cb(ackermann_msgs::msg::AckermannDrive::SharedPtr msg);
 
     rclcpp::Subscription<ackermann_msgs::msg::AckermannDrive>::SharedPtr ack_sub;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub;
     ackermann_msgs::msg::AckermannDrive control;
+    webots_ros2_driver::WebotsNode* parent;
+
+    ~WbIoRos() { wbu_driver_cleanup(); }
 };
 }  // namespace wb_io_ros

--- a/wb_io_ros/package.xml
+++ b/wb_io_ros/package.xml
@@ -3,8 +3,8 @@
 <package format="3">
   <name>wb_io_ros</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="Andrew@Ealovega.dev">andy</maintainer>
+  <description>A webots plugin to interface with Phoenix</description>
+  <maintainer email="avealov@umich.edu">andy</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -12,6 +12,7 @@
   <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
   <depend>ackermann_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>webots_ros2_driver</depend>
   <depend>pluginlib</depend>
 

--- a/wb_io_ros/package.xml
+++ b/wb_io_ros/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>wb_io_ros</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="Andrew@Ealovega.dev">andy</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>ackermann_msgs</depend>
+  <depend>webots_ros2_driver</depend>
+  <depend>pluginlib</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/wb_io_ros/src/wb_io_ros.cpp
+++ b/wb_io_ros/src/wb_io_ros.cpp
@@ -1,25 +1,34 @@
 #include "wb_io_ros/wb_io_ros.hpp"
 
-#include <webots/motor.h>
-#include <webots/robot.h>
-
-#include <cstdio>
 #include <functional>
-
-#include "rclcpp/rclcpp.hpp"
 
 namespace wb_io_ros {
 void WbIoRos::init(webots_ros2_driver::WebotsNode* node, std::unordered_map<std::string, std::string>& parameters) {
-    ack_sub = node->create_subscription<ackermann_msgs::msg::AckermannDrive>(
-        "/ack_vel", rclcpp::SensorDataQoS().reliable(), std::bind(&WbIoRos::ack_cb, this, std::placeholders::_1));
+    wbu_driver_init();
 
-    // TODO get driver api things
+    // Store owning node
+    this->parent = node;
+
+    ack_sub = node->create_subscription<ackermann_msgs::msg::AckermannDrive>(
+        "/ack_vel", 5, std::bind(&WbIoRos::ack_cb, this, std::placeholders::_1));
+    odom_pub = node->create_publisher<nav_msgs::msg::Odometry>("/odom_can", 10);
 }
 
 void WbIoRos::ack_cb(const ackermann_msgs::msg::AckermannDrive::SharedPtr msg) { this->control = *msg; }
 
 void WbIoRos::step() {
-    // TODO assign controls
+    wbu_driver_step();
+
+    // Capture encoder value as odom
+    nav_msgs::msg::Odometry odom{};
+    odom.header.stamp = parent->get_clock()->now();
+    // Convert from kph to mps
+    odom.twist.twist.linear.x = wbu_driver_get_current_speed() / 3.6;
+    this->odom_pub->publish(odom);
+
+    // Actuate the car, converting from ros units
+    wbu_driver_set_cruising_speed(this->control.speed * 3.6);
+    wbu_driver_set_steering_angle(-this->control.steering_angle);
 }
 }  // namespace wb_io_ros
 

--- a/wb_io_ros/src/wb_io_ros.cpp
+++ b/wb_io_ros/src/wb_io_ros.cpp
@@ -23,7 +23,7 @@ void WbIoRos::step() {
     nav_msgs::msg::Odometry odom{};
     odom.header.stamp = parent->get_clock()->now();
     // Convert from kph to mps
-    odom.twist.twist.linear.x = wbu_driver_get_current_speed() / 3.6;
+    odom.twist.twist.linear.x = wbu_driver_get_current_speed() / 7.2;
     this->odom_pub->publish(odom);
 
     // Actuate the car, converting from ros units

--- a/wb_io_ros/src/wb_io_ros.cpp
+++ b/wb_io_ros/src/wb_io_ros.cpp
@@ -1,0 +1,27 @@
+#include "wb_io_ros/wb_io_ros.hpp"
+
+#include <webots/motor.h>
+#include <webots/robot.h>
+
+#include <cstdio>
+#include <functional>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace wb_io_ros {
+void WbIoRos::init(webots_ros2_driver::WebotsNode* node, std::unordered_map<std::string, std::string>& parameters) {
+    ack_sub = node->create_subscription<ackermann_msgs::msg::AckermannDrive>(
+        "/ack_vel", rclcpp::SensorDataQoS().reliable(), std::bind(&WbIoRos::ack_cb, this, std::placeholders::_1));
+
+    // TODO get driver api things
+}
+
+void WbIoRos::ack_cb(const ackermann_msgs::msg::AckermannDrive::SharedPtr msg) { this->control = *msg; }
+
+void WbIoRos::step() {
+    // TODO assign controls
+}
+}  // namespace wb_io_ros
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(wb_io_ros::WbIoRos, webots_ros2_driver::PluginInterface)

--- a/wb_io_ros/wb_io_ros.xml
+++ b/wb_io_ros/wb_io_ros.xml
@@ -1,0 +1,9 @@
+<library path="wb_io_ros">
+    <!-- The `type` attribute is a reference to the plugin class. -->
+    <!-- The `base_class_type` attribute is always `webots_ros2_driver::PluginInterface`. -->
+    <class type="wb_io_ros::WbIoRos" base_class_type="webots_ros2_driver::PluginInterface">
+        <description>
+            Phoenix webots driver
+        </description>
+    </class>
+</library>


### PR DESCRIPTION
This PR adds wb_io_ros, a plugin for webots_ros2_driver that acts the same as the other two. This primarly forwards odom from webots, and actuates the kart in sim from ackermann messages.